### PR TITLE
rename status variable to statusElem, so it doesnt conflict with window.status

### DIFF
--- a/demos/nav-online.html
+++ b/demos/nav-online.html
@@ -4,10 +4,10 @@
   <p>A timer is constantly polling the navigator.onLine property, which is typically switched via File -&gt; Work Offline</p>
 </article>
 <script>
-var status = document.getElementById('status')
+var statusElem = document.getElementById('status')
 
 setInterval(function () {
-  status.className = navigator.onLine ? 'online' : 'offline';
-  status.innerHTML = navigator.onLine ? 'online' : 'offline';  
+  statusElem.className = navigator.onLine ? 'online' : 'offline';
+  statusElem.innerHTML = navigator.onLine ? 'online' : 'offline';  
 }, 250);
 </script>

--- a/demos/offline.html
+++ b/demos/offline.html
@@ -4,12 +4,12 @@
   <ol id="state"></ol>
 </article>
 <script>
-var status = document.getElementById('status'),
-    state = document.getElementById('state');
+var statusElem  = document.getElementById('status'),
+    state 		= document.getElementById('state');
 
 function online(event) {
-  status.className = navigator.onLine ? 'online' : 'offline';
-  status.innerHTML = navigator.onLine ? 'online' : 'offline';
+  statusElem.className = navigator.onLine ? 'online' : 'offline';
+  statusElem.innerHTML = navigator.onLine ? 'online' : 'offline';
   state.innerHTML += '<li>New event: ' + event.type + '</li>';
 }
 


### PR DESCRIPTION
window.status can cast objects to string when `status` is being used as the variable.
which was causing these tests to fail in chrome.
:)
