### PR TITLE
Use preload="auto" on videos that expect to get the canplay event

### DIFF
--- a/demos/two-videos.html
+++ b/demos/two-videos.html
@@ -10,11 +10,11 @@ video {
 </style>
 <title>Two videos in sync</title>
 <article>
-  <video id="one">
+  <video preload="auto" id="one">
     <source src="assets/dizzy.mp4" />
     <source src="assets/dizzy.ogv" />
   </video>    
-  <video id="two">
+  <video preload="auto" id="two">
     <source src="assets/dizzy.mp4" />
     <source src="assets/dizzy.ogv" />
   </video>


### PR DESCRIPTION
Since the default state is metadata, there's no guarantee that the
videos will reach anything beyond HAVE_CURRENT_DATA, but the canplay
event is fired when reaching HAVE_FUTURE_DATA.
