### PR TITLE
Opera supports getUserMedia and also drag&drop in the latest stable version

### DIFF
--- a/demos.json
+++ b/demos.json
@@ -4,8 +4,8 @@
     "url": "gum-canvas",
     "tags": "getUserMedia canvas",
     "support": {
-      "live": "",
-      "nightly": "chrome opera"
+      "live": "opera",
+      "nightly": "chrome"
     },
     "test": "navigator.getUserMedia !== undefined"
   },
@@ -14,8 +14,8 @@
     "url": "gum",
     "tags": "getUserMedia",
     "support": {
-      "live": "",
-      "nightly": "chrome opera"
+      "live": "opera",
+      "nightly": "chrome"
     },
     "test": "navigator.getUserMedia !== undefined"
   },
@@ -24,7 +24,7 @@
     "url": "dnd-upload",
     "tags": "file dnd xhr2",
     "support": {
-      "live": "chrome firefox",
+      "live": "chrome firefox opera",
       "nightly": "ie"
     },
     "test": "typeof FileReader != 'undefined' && 'draggable' in document.createElement('span') && !!window.FormData && 'upload' in new XMLHttpRequest"
@@ -94,7 +94,7 @@
     "note": "Not directly part of HTML5",
     "tags": "file-api dnd",
     "support": {
-      "live": "firefox chrome"
+      "live": "firefox chrome opera"
     },
     "test": "typeof FileReader != 'undefined' && Modernizr.draganddrop"
   },
@@ -103,8 +103,8 @@
     "url": "web-socket",
     "tags": "websocket",
     "support": {
-      "live": "safari chrome",
-      "nightly": "firefox opera"
+      "live": "safari chrome opera",
+      "nightly": "firefox"
     },
     "test": "Modernizr.websockets"
   },
@@ -197,7 +197,7 @@
     "url": "drag",
     "tags": "dnd",
     "support": {
-      "live": "ie firefox safari chrome"
+      "live": "ie firefox safari chrome opera"
     },
     "test": "Modernizr.draganddrop"
   },
@@ -206,7 +206,7 @@
     "url": "drag-anything",
     "tags": "dnd",
     "support": {
-      "live": "ie firefox safari chrome"
+      "live": "ie firefox safari chrome opera"
     },
     "test": "Modernizr.draganddrop"
   },


### PR DESCRIPTION
As you suggested earlier, here's the pull request.

Opera now supports getUserMedia, drag&drop and XHR2 in the latest stable version
Tested on Opera 12.00 Linux/i386 and Windows.
