### PR TITLE
This makes it work

### DIFF
--- a/demos/contenteditable.html
+++ b/demos/contenteditable.html
@@ -38,4 +38,12 @@ if (localStorage.getItem('contenteditable')) {
   editable.innerHTML = localStorage.getItem('contenteditable');
 }
 
+(function fix(){
+    var a = editable.parentElement.innerHTML;
+    editable.parentElement.innerHTML+='bob';
+    document.getElementById('editable').parentElement.innerHTML = a;
+    editable = document.getElementById('editable');
+    document.getElementById('clear').onclick=function(){location.reload()};
+})()
+
 </script>


### PR DESCRIPTION
No idea why, but resetting the parentElement's innerHTML makes it editable again on Chrome 37. Will have to look into it more when not at work.
